### PR TITLE
🐛 Fix: CI 실패시 확인을 위한 리포트 업로드 기능 추가(CI.yml)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,21 +1,34 @@
 name: CI with Gradle
 
-# develop, main에 PR이 생성될 때 실행
+# develop, main 브랜치에 PR이 생성될 때 CI 파이프라인 실행
 on:
   pull_request:
     branches: [ "develop", "main" ]
 
 jobs:
   test:
+    name: Run Unit Tests
     runs-on: ubuntu-latest
 
     steps:
+      # GitHub 저장소 코드 체크아웃
       - uses: actions/checkout@v4
+
+      # JDK 17 설치
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
+
       # Gradle 테스트 실행
       - name: Run Tests
-        run: ./gradlew clean test --info
+        run: ./gradlew clean test --info --stacktrace
+
+      # 테스트 실패 시 HTML 리포트 업로드
+      - name: Upload Test Report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- #10 

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
1. Github Actions CI 파이프라인에 테스트 실패 시 리포트 업로드하는 기능 추가
2. 테스트 실패 원인 파악을 위해 작업 진행


<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
3. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->
1. **CI 실패 시 GitHub Actions 하단의 Artifacts 탭에서 테스트 리포트를 확인하실 수 있습니다.**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e79c37de-d83c-410b-bbc3-bda16a0b44fe" />
<br><br>

아래와 같이 html로 확인도 가능합니다.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/a5a9fd9c-32d6-4f63-b8e6-127a6b4a31fe" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b3486fa5-a63d-4c30-a1d8-80c0e39d31cc" />

<br></br>
2. 향후 Discord 알림 도입도 고려중입니다.


<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
