### PR TITLE
🐛 Fix: ReportCreateResponse DTO 필드명 오타 수정

### DIFF
--- a/src/main/java/com/likelion/server/domain/report/web/dto/ReportCreateResponse.java
+++ b/src/main/java/com/likelion/server/domain/report/web/dto/ReportCreateResponse.java
@@ -1,4 +1,4 @@
 package com.likelion.server.domain.report.web.dto;
 
-public record ReportCreateResponse(Long repostId) {
+public record ReportCreateResponse(Long reportId) {
 }


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
close #75 
<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
1. 레포트 생성 Response 필드명 오타를 수정했습니다.
- respostId -> reportId

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
3. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->
이제 레포트 생성 통신 시 reportId로 통신하시면 됩니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
