### PR TITLE
🐛 Fix: 최신 레포트 상세 조회시 email(udiq) 기반으로 최신 Report 한 건만 조회되도록 수정

### DIFF
--- a/src/main/java/com/likelion/server/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/likelion/server/domain/report/repository/ReportRepository.java
@@ -7,14 +7,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
-    // 이메일, 비밀번호로 리포트 조회
-    Optional<Report> findByIdea_User_EmailAndIdea_User_Password(
-            String email, String password
-    );
+    // 이메일로 최신 레포트 한 건 조회
+    Optional<Report> findTopByIdea_User_EmailOrderByCreatedAtDesc(String email);
 
-    // Report ID로 리포트 조회
+
+    // Report ID로 레포트 조회
     Optional<Report> findById(Long reportId);
 
-    // 특정 아이디어의 최신 리포트 한 건 조회
+    // 특정 아이디어의 최신 레포트 한 건 조회
     Optional<Report> findTopByIdeaIdOrderByCreatedAtDesc(Long ideaId);
 }

--- a/src/main/java/com/likelion/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/report/service/ReportServiceImpl.java
@@ -138,7 +138,7 @@ public class ReportServiceImpl implements ReportService {
 
         // 회원 레포트 조회
         Report report = reportRepository
-                .findByIdea_User_EmailAndIdea_User_Password(user.getEmail(), user.getPassword())
+                .findTopByIdea_User_EmailOrderByCreatedAtDesc(user.getEmail())
                 .orElseThrow(ReportNotFoundException::new);
 
         return toResponse(report);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 spring.application.name=server
 server.servlet.context-path=/api
 server.base-url=http://localhost:8080
+#fastapi.base-url=http://localhost:8000
 fastapi.base-url=https://43.202.138.216.nip.io
 
 # secret


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
close #109 
<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
1. 최근 레포트 상세 조회 에서 report 조회 로직 수정
- 기존에는 email, pwd 기반으로 JPA에서 Report 하나를 바로 반환했는데, user는 하나더라도 report가 여러 개 있을 수 있어서 간헐적으로 여러 건이 잡히면서 500 에러가 발생했습니다. 
- email에 uniq 제약이 있으므로 email 기반으로 해당 user의 report들 중 최신 1건만 반환하도록 수정했습니다.
<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
3. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
### 최신 레포트 상세 조회
> 200 (조회 성공)
<img width="450" height="304" alt="image" src="https://github.com/user-attachments/assets/0a893891-fd6b-4f04-99d1-73c3b3ca7689" />

